### PR TITLE
API Move queue dependencies under service layer

### DIFF
--- a/_config/queuedjobs.yml
+++ b/_config/queuedjobs.yml
@@ -7,6 +7,7 @@ Injector:
   QueuedJobService:
     properties: 
       queueHandler: %$QueueHandler
+      queueRunner: %$DoormanRunner
   DefaultRule:
     class: 'AsyncPHP\Doorman\Rule\InMemoryRule'
     properties:
@@ -15,8 +16,7 @@ Injector:
       MaximumProcessorUsage: 100
   ProcessJobQueueTask:
     properties:
-      # Change to DoormanRunner for async processing
-      TaskRunner: %$QueueRunner
+      queuedJobService: %$QueuedJobService
   DoormanRunner:
     properties:
       DefaultRules:

--- a/code/services/QueuedJobService.php
+++ b/code/services/QueuedJobService.php
@@ -77,6 +77,11 @@ class QueuedJobService {
 	 */
 	public $queueHandler;
 	
+	/**
+	 *
+	 * @var TaskRunnerEngine
+	 */
+	public $queueRunner;
 
 	/**
 	 * Register our shutdown handler
@@ -754,6 +759,11 @@ class QueuedJobService {
 		}
 
 		return $filter;
+	}
+	
+	public function runQueue($queue) {
+		$this->checkJobHealth();
+		$this->queueRunner->runQueue($queue);
 	}
 
 	/**

--- a/code/tasks/ProcessJobQueueTask.php
+++ b/code/tasks/ProcessJobQueueTask.php
@@ -9,26 +9,9 @@
 class ProcessJobQueueTask extends BuildTask {
 
 	/**
-	 *
-	 * @var TaskRunnerEngine
+	 * @var QueuedJobService
 	 */
-	protected $taskRunner;
-
-	/**
-	 * @param TaskRunnerEngine $engine
-	 */
-	public function setTaskRunner($engine) {
-		$this->taskRunner = $engine;
-	}
-
-	/**
-	 *
-	 * @return TaskRunnerEngine
-	 */
-	public function getTaskRunner() {
-		return $this->taskRunner;
-	}
-
+	public $queuedJobService;
 	/**
 	 * @return string
 	 */
@@ -62,9 +45,7 @@ class ProcessJobQueueTask extends BuildTask {
 
 		// Run the queue
 		$queue = $this->getQueue($request);
-		$this
-			->getTaskRunner()
-			->runQueue($queue);
+		$this->queuedJobService->runQueue($queue);
 	}
 
 	/**

--- a/code/tasks/engines/DoormanRunner.php
+++ b/code/tasks/engines/DoormanRunner.php
@@ -35,11 +35,6 @@ class DoormanRunner extends BaseRunner implements TaskRunnerEngine {
 	 * @param string $queue
 	 */
 	public function runQueue($queue) {
-		// fix/prep any strange jobs!
-		$this
-			->getService()
-			->checkJobHealth();
-
 		// split jobs out into multiple tasks...
 
 		$manager = new DoormanProcessManager();

--- a/code/tasks/engines/QueueRunner.php
+++ b/code/tasks/engines/QueueRunner.php
@@ -10,7 +10,6 @@ class QueueRunner extends BaseRunner implements TaskRunnerEngine {
 	 */
 	public function runQueue($queue) {
 		$service = $this->getService();
-		$service->checkJobHealth();
 		
 		$nextJob = $service->getNextPendingJob($queue);
 		$this->logDescriptorStatus($nextJob, $queue);


### PR DESCRIPTION
Moved the dependency utilisation underneath the service layer's
responsibilities instead of the job queue task, so that delegation
isn't a controller responsibility.
